### PR TITLE
[layout] Fix inconsistent widths in horizontal/vertical layouts

### DIFF
--- a/nn.h
+++ b/nn.h
@@ -751,38 +751,18 @@ Gym_Rect gym_layout_slot_loc(Gym_Layout *l, const char *file_path, int line)
 
     switch (l->orient) {
     case GLO_HORZ:
-        r.w = l->rect.w/l->count;
+        r.w = (l->rect.w + l->gap)/l->count - l->gap;
         r.h = l->rect.h;
-        r.x = l->rect.x + l->i*r.w;
+        r.x = l->rect.x + l->i*(r.w + l->gap);
         r.y = l->rect.y;
-
-        if (l->i == 0) { // First
-            r.w -= l->gap/2;
-        } else if (l->i >= l->count - 1) { // Last
-            r.x += l->gap/2;
-            r.w -= l->gap/2;
-        } else { // Middle
-            r.x += l->gap/2;
-            r.w -= l->gap;
-        }
 
         break;
 
     case GLO_VERT:
         r.w = l->rect.w;
-        r.h = l->rect.h/l->count;
+        r.h = (l->rect.h + l->gap)/l->count - l->gap;
         r.x = l->rect.x;
-        r.y = l->rect.y + l->i*r.h;
-
-        if (l->i == 0) { // First
-            r.h -= l->gap/2;
-        } else if (l->i >= l->count - 1) { // Last
-            r.y += l->gap/2;
-            r.h -= l->gap/2;
-        } else { // Middle
-            r.y += l->gap/2;
-            r.h -= l->gap;
-        }
+        r.y = l->rect.y + l->i*(r.h + l->gap);
 
         break;
 


### PR DESCRIPTION
We get the size of each widget in the layout by adding a "phantom" gap at the end, then divide the new width by the number of slots to get how wide each slot + its gap is. 

This makes it each slot has a gap after it (the final slot gets the "phantom" gap), and so all slots get the same width (unlike before where the first and last slot were wider).

Furthermore this fixes a minor bug that occurs when you have a layout with just 1 item, where you would get a gap after it which makes it not take up the full width available. (This is unlikely to happen if you're designing the layout by hand, but could happen if you generate it from, say, a list of items)