### PR TITLE
Small backprop optimization, fix gym.h

### DIFF
--- a/gym.h
+++ b/gym.h
@@ -272,7 +272,7 @@ void gym_nn_image_grayscale(NN nn, void *pixels, size_t width, size_t height, si
             float a = ROW_AT(NN_OUTPUT(nn), 0);
             if (a < low) a = low;
             if (a > high) a = high;
-            uint32_t pixel = (a + low)/(high - low)*255.f;
+            uint32_t pixel = (a - low)/(high - low)*255.f;
             pixels_u32[y*stride + x] = (0xFF<<(8*3))|(pixel<<(8*2))|(pixel<<(8*1))|(pixel<<(8*0));
         }
     }

--- a/nn.h
+++ b/nn.h
@@ -400,9 +400,9 @@ NN nn_backprop(Region *r, NN nn, Mat t)
 
         for (size_t j = 0; j < out.cols; ++j) {
 #ifdef NN_BACKPROP_TRADITIONAL
-            ROW_AT(NN_OUTPUT(g), j) = 2*(ROW_AT(NN_OUTPUT(nn), j) - ROW_AT(out, j));
+            ROW_AT(NN_OUTPUT(g), j) = 2.0f/n*(ROW_AT(NN_OUTPUT(nn), j) - ROW_AT(out, j));
 #else
-            ROW_AT(NN_OUTPUT(g), j) = ROW_AT(NN_OUTPUT(nn), j) - ROW_AT(out, j);
+            ROW_AT(NN_OUTPUT(g), j) = 1.0f/n*(ROW_AT(NN_OUTPUT(nn), j) - ROW_AT(out, j));
 #endif // NN_BACKPROP_TRADITIONAL
         }
 
@@ -427,17 +427,6 @@ NN nn_backprop(Region *r, NN nn, Mat t)
                     ROW_AT(g.as[l-1], k) += s*da*qa*w;
                 }
             }
-        }
-    }
-
-    for (size_t i = 0; i < g.arch_count-1; ++i) {
-        for (size_t j = 0; j < g.ws[i].rows; ++j) {
-            for (size_t k = 0; k < g.ws[i].cols; ++k) {
-                MAT_AT(g.ws[i], j, k) /= n;
-            }
-        }
-        for (size_t k = 0; k < g.bs[i].cols; ++k) {
-            ROW_AT(g.bs[i], k) /= n;
         }
     }
 


### PR DESCRIPTION
Instead of averaging every parameter's gradient at the end, just average the output gradient at the start, reducing the number of divisions. This is equivalent because the `1/n` term propagates backwards to all the gradients.